### PR TITLE
ignoring some new phpstan errors, fixing travis cache config for future builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,17 @@ language: php
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - vendor
+
 env:
   global:
-    - COMPOSER_ARGS="" TMPDIR=/tmp USE_XDEBUG=false
+    - COMPOSER_ARGS=""
+    - TMPDIR=/tmp
+    - USE_XDEBUG=false
+    - COMPOSER_DISCARD_CHANGES=1
 
 branches:
   only:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,3 +20,14 @@ parameters:
         -
             message: '#Return type \(Zend_EventManager_Filter_FilterIterator\) of method Zend_EventManager_FilterChain::getFilters\(\) should be compatible with return type \(array\) of method Zend_EventManager_Filter::getFilters\(\)#'
             path: %currentWorkingDirectory%/src/Zend/EventManager/FilterChain.php
+
+        # Defensive coding, types can't be enforced via php type-hints
+        -
+            message: '#Result of && is always false\.#'
+            path: %currentWorkingDirectory%/src/Zend/EventManager/Event.php
+        -
+            message: '#Else branch is unreachable because ternary operator condition is always true\.#'
+            path: %currentWorkingDirectory%/src/Zend/EventManager/Event.php
+        -
+            message: '#Else branch is unreachable because ternary operator condition is always true.#'
+            path: %currentWorkingDirectory%/src/Zend/EventManager/EventManager.php


### PR DESCRIPTION
Phpstan update revealed some new errors, just ignoring those though since they're defensive coding situations that shouldn't be changed.

Also updating travis config a bit to deal with caching issues and composer.